### PR TITLE
Changing setFree([integer]) to setFree([bool])

### DIFF
--- a/python/IntegralUpperLimit.py
+++ b/python/IntegralUpperLimit.py
@@ -113,7 +113,7 @@ def _loglike(x, like, par, srcName, offset, verbosity, no_optimizer,
     # Optimizer uses verbosity level one smaller than given here
     optverbosity = max(verbosity-1, 0)
 
-    par.setFree(0)
+    par.setFree()
     par.setValue(x)
     like.syncSrcParams(srcName)
 
@@ -492,7 +492,7 @@ def calc_int(like, srcName, cl=0.95, verbosity=0,
     fitstat = None
     if not skip_global_opt:
         # Make sure desired parameter is free during global optimization
-        par.setFree(1)
+        par.setFree(True)
         like.syncSrcParams(srcName)
 
         # Perform global optimization
@@ -526,11 +526,11 @@ def calc_int(like, srcName, cl=0.95, verbosity=0,
     # Freeze all other model parameters if requested (much faster!)
     if(freeze_all):
         for i in range(len(like.model.params)):
-            like.model[i].setFree(0)
+            like.model[i].setFree(False)
             like.syncSrcParams(like[i].srcName)
 
     # Freeze the parameter of interest
-    par.setFree(0)
+    par.setFree(False)
     like.syncSrcParams(srcName)
 
     # Set up the caches for the optimum values and nuisance parameters
@@ -890,7 +890,7 @@ def calc_chi2(like, srcName, cl=0.95, verbosity=0,
     fitstat = None
     if not skip_global_opt:
         # Make sure desired parameter is free during global optimization
-        par.setFree(1)
+        par.setFree(True)
         like.syncSrcParams(srcName)
 
         # Perform global optimization
@@ -922,11 +922,11 @@ def calc_chi2(like, srcName, cl=0.95, verbosity=0,
     # Freeze all other model parameters if requested (much faster!)
     if(freeze_all):
         for i in range(len(like.model.params)):
-            like.model[i].setFree(0)
+            like.model[i].setFree(False)
             like.syncSrcParams(like[i].srcName)
 
     # Freeze the parameter of interest
-    par.setFree(0)
+    par.setFree(False)
     like.syncSrcParams(srcName)
 
     # Set up the caches for the optimum values and nuisance parameters
@@ -1050,7 +1050,7 @@ if __name__ == "__main__":
     src_spectrum = like[srcName].funcs['Spectrum']
     par = src_spectrum.getParam("Index")
     if par:
-        par.setFree(0)
+        par.setFree(False)
         par.setValue(-2.0)
         like.syncSrcParams(srcName)
 

--- a/python/IntegralUpperLimit.py
+++ b/python/IntegralUpperLimit.py
@@ -113,7 +113,7 @@ def _loglike(x, like, par, srcName, offset, verbosity, no_optimizer,
     # Optimizer uses verbosity level one smaller than given here
     optverbosity = max(verbosity-1, 0)
 
-    par.setFree()
+    par.setFree(False)
     par.setValue(x)
     like.syncSrcParams(srcName)
 

--- a/python/SED.py
+++ b/python/SED.py
@@ -251,7 +251,7 @@ class SED(object):
 
         index=like[like.par_index(name, 'Index')]
         index.setTrueValue(self.powerlaw_index)
-        index.setFree(0)
+        index.setFree(False)
         like.syncSrcParams(name)
 
         # assume a canonical dnde=1e-11 at 1GeV index 2 starting value

--- a/python/SrcAnalysis.py
+++ b/python/SrcAnalysis.py
@@ -240,9 +240,9 @@ class SrcAnalysis(object):
             lines.append(item.__repr__().strip("'"))
         return '\n'.join(lines)
     def thaw(self, i):
-        self.model[i].setFree(1)
+        self.model[i].setFree(True)
     def freeze(self, i):
-        self.model[i].setFree(0)
+        self.model[i].setFree(False)
 
 if __name__ == '__main__':
     observation = Observation('galdiffuse_events_0000.fits',

--- a/src/pyLikelihood.h
+++ b/src/pyLikelihood.h
@@ -356,7 +356,7 @@ underlying C++ class from Python so that one can set the "free" flag, set
 the bounds, and the scale factor
 
 @verbatim
->>> like.model[1].setFree(1)
+>>> like.model[1].setFree(True)
 >>> like.model[3].setScale(1e-2)
 >>> like.model[3] = 1.1
 >>> like.model[3].setBounds(0.5, 2)


### PR DESCRIPTION
Completing the move from `setFree(0)` to `setFree(False)` and `setFree(1)` to `setFree(True)` for the parameter class. This is due to compatibility issues between the integer form and `swig` on Mac.