### PR TITLE
Fix restoration of parameters to handle nested parameters

### DIFF
--- a/python/LikelihoodState.py
+++ b/python/LikelihoodState.py
@@ -38,8 +38,13 @@ class _Parameter(object):
         if par is None:
             par = self.par
             return
-        par.setDataValues(self.par)
-
+        #For SummedLikelihood objects, there are multiple parameters that need to be updated,,
+        try:  #If it's at SummedLikelihood objects with multiple components, this will work
+            for param in par.pars:
+                param.setDataValues(self.par)
+        except:  # otherwise, fall back on original behaviour.
+            par.setDataValues(self.par)
+        #par.setEquals(self.par)
 
 class LikelihoodState(object):
     """Save the parameter state of a pyLikelihood object and provide a


### PR DESCRIPTION
This fixes the issue reported in issue 19 (https://github.com/fermi-lat/pyLikelihood/issues/19).

With a SummedLikelihood object, the parameter object has multiple components and only the first was being updated.  The fix now tries to update all components and if the component list isn't there, falls back on the original behavior.  This fix passes the test cases supplied in both issue 19 (linked above), and the test case supplied as part of Likelihood issue #76 (https://github.com/fermi-lat/Likelihood/issues/76)