### PR TITLE
fix Likelihood scan() with fix_src_pars=True

### DIFF
--- a/python/AnalysisBase.py
+++ b/python/AnalysisBase.py
@@ -792,8 +792,8 @@ class AnalysisBase(object):
                 break
 
         if fix_src_pars:
-            freePars = self.like.freePars(srcName)
-            self.setFreeFlag(srcName, freePars, 0)
+            freePars = self.freePars(srcName)
+            self.setFreeFlag(srcName, freePars, False)
             self.syncSrcParams(srcName)
 
         if tol is None:


### PR DESCRIPTION
Fix crash of Likelihood scan() when fix_src_pars=True
https://github.com/fermi-lat/pyLikelihood/issues/22